### PR TITLE
Improve handling of {cp, undefined}

### DIFF
--- a/src/eflame.erl
+++ b/src/eflame.erl
@@ -116,6 +116,12 @@ trace_proc_stream({trace_ts, _Ps, call, MFA, {cp, {_,_,_} = CallerMFA}, Ts}, #du
 trace_proc_stream({trace_ts, _Ps, call, MFA, {cp, undefined}, Ts}, #dump{stack=[]} = State) ->
     new_state(State, [MFA], Ts);
 
+trace_proc_stream({trace_ts, _Ps, call, MFA, {cp, undefined}, Ts}, #dump{stack=[MFA|_] = Stack} = State) ->
+    new_state(State, Stack, Ts);
+
+trace_proc_stream({trace_ts, _Ps, call, MFA, {cp, undefined}, Ts}, #dump{stack=Stack} = State) ->
+    new_state(State, [MFA | Stack], Ts);
+
 trace_proc_stream({trace_ts, _Ps, call, MFA, {cp, MFA}, Ts}, #dump{stack=[MFA|Stack]} = State) ->
     new_state(State, [MFA|Stack], Ts); % collapse tail recursion
 


### PR DESCRIPTION
Hi, I think the handling of {cp, undefined} is currently broken. Resetting the call stack is not OK since most of the time we can guess the stack. I've attached a preliminary patch, but I'm not sure it fixes all cases.    

The {cp, undefined} issue is due to call to BIFs (and possibly NIFs):

    Note that if a "technically built in function" (i.e. a function not written in Erlang) is traced, the caller function will sometimes return the atom undefined. The calling Erlang function is not available during such calls.

from http://www.erlang.org/doc/apps/erts/match_spec.html