### PR TITLE
Add configurable timeout for stop_trace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ ebin/*
 *.svg
 *.out
 erl_crash.dump
+.rebar


### PR DESCRIPTION
This is working for me. I'm less familiar with erlang, so it might not be idiomatic. I looked into using proplists for the Options argument, but it doesn't seem to have a convenient guard that would work. Using a map, the calling syntax from Elixir is not idiomatic, but I'm not sure that matters.

Feedback welcome.

Fixes https://github.com/proger/eflame/issues/13