### PR TITLE
Various improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ ebin/*
 *.svg
 *.out
 erl_crash.dump
+_build/
+rebar.lock

--- a/rebar.config
+++ b/rebar.config
@@ -1,0 +1,1 @@
+{erl_opts, [debug_info]}.

--- a/src/eflame.erl
+++ b/src/eflame.erl
@@ -131,7 +131,7 @@ trace_listener(State0) ->
   end.
 
 us({Mega, Secs, Micro}) ->
-  Mega * 1000 * 1000 * 1000 * 1000 + Secs * 1000 * 1000 + Micro.
+  Mega * 1000000000000 + Secs * 1000000 + Micro.
 
 new_state(#dump{us = 0} = State, Stack, Ts) ->
   UsTs = us(Ts),

--- a/src/eflame.erl
+++ b/src/eflame.erl
@@ -42,8 +42,8 @@ do_apply(Mode, OutputFile, {Fun, Args}) ->
 
   start_trace(Tracer, self(), Mode),
 
-  F   = build_fun(Fun, Args),
-  Ref = apply_fun(F, self()),
+  F      = build_fun(Fun, Args),
+  Ref    = apply_fun(F, self()),
   Result = wait_result(Ref, ?DEFAULT_TIMEOUT),
   {ok, Bytes} = stop_trace(Tracer, self()),
 
@@ -114,12 +114,10 @@ trace_listener(State0) ->
       IOList = [ dump_to_iolist(TPid, Dump#dump.acc)
                  || {TPid, Dump} <- maps:to_list(State0)
                ],
-      %% ?LOG("~p", [IOList]),
 
       Bytes = iolist_to_binary(IOList),
       Pid ! {bytes, Bytes};
     Term ->
-      %% ?LOG("~p~n", [Term]),
       trace_ts  = element(1, Term),
       Pid       = element(2, Term),
 

--- a/src/eflame.erl
+++ b/src/eflame.erl
@@ -212,7 +212,7 @@ stack_collapse(Stack) ->
 entry_to_iolist({M, F, A}) ->
   [ atom_to_binary(M, utf8), <<":">>
   , atom_to_binary(F, utf8), <<"/">>
-  , integer_to_list(A)
+  , integer_to_binary(A)
   ];
 entry_to_iolist(A) when is_atom(A) ->
   [atom_to_binary(A, utf8)].
@@ -231,13 +231,11 @@ dump_to_iolist(Pid, Stacks) ->
 dump_to_iolist(_PidList, [], Result) ->
   Result;
 dump_to_iolist(PidList, [{N, Stack} | Rest], Result) ->
-  Item  = stack_to_iolist(PidList, Stack),
-  Items = lists:duplicate(N, Item),
-  dump_to_iolist(PidList, Rest, [Items | Result]);
-dump_to_iolist(PidList, [Stack | Rest], Result) ->
-  Item = stack_to_iolist(PidList, Stack),
+  Item  = stack_to_iolist(PidList, N, Stack),
   dump_to_iolist(PidList, Rest, [Item | Result]).
 
--spec stack_to_iolist(string(), list()) -> iolist().
-stack_to_iolist(PidList, Stack) ->
-  [PidList, <<";">>, stack_collapse(Stack), <<"\n">>].
+-spec stack_to_iolist(string(), integer(), list()) -> iolist().
+stack_to_iolist(PidList, N, Stack) ->
+  [ PidList, <<";">>, stack_collapse(Stack)
+  ,  <<" ">>, integer_to_binary(N)
+  , <<"\n">>].

--- a/src/eflame.erl
+++ b/src/eflame.erl
@@ -26,11 +26,14 @@ apply1(Mode, OutputFile, {Fun, Args}) ->
     Tracer = spawn_tracer(),
 
     start_trace(Tracer, self(), Mode),
-    Return = (catch apply_fun(Fun, Args)),
+
+    spawn_link(fun() -> apply_fun(Fun, Args) end),
+
+    timer:sleep(10000),
+
     {ok, Bytes} = stop_trace(Tracer, self()),
 
-    ok = file:write_file(OutputFile, Bytes),
-    Return.
+    ok = file:write_file(OutputFile, Bytes).
 
 apply_fun({M, F}, A) ->
     erlang:apply(M, F, A);
@@ -169,4 +172,3 @@ intercalate(Sep, Xs) -> lists:concat(intersperse(Sep, Xs)).
 intersperse(_, []) -> [];
 intersperse(_, [X]) -> [X];
 intersperse(Sep, [X | Xs]) -> [X, Sep | intersperse(Sep, Xs)].
-

--- a/src/eflame.erl
+++ b/src/eflame.erl
@@ -242,4 +242,4 @@ dump_to_iolist(PidList, [Stack | Rest], Result) ->
 
 -spec stack_to_iolist(string(), list()) -> iolist().
 stack_to_iolist(PidList, Stack) ->
-  [ PidList, <<";">>, stack_collapse(Stack), <<"\n">>].
+  [PidList, <<";">>, stack_collapse(Stack), <<"\n">>].

--- a/src/eflame.erl
+++ b/src/eflame.erl
@@ -1,171 +1,189 @@
 -module(eflame).
+
 -export([apply/2,
          apply/3,
          apply/4,
          apply/5]).
 
 -define(RESOLUTION, 1000). %% us
--record(dump, {stack=[], us=0, acc=[]}). % per-process state
+-record(dump, {stack = [], us = 0, acc = []}). % per-process state
 
 -define(DEFAULT_MODE, normal_with_children).
 -define(DEFAULT_OUTPUT_FILE, "stacks.out").
 
 apply(F, A) ->
-    apply1(?DEFAULT_MODE, ?DEFAULT_OUTPUT_FILE, {F, A}).
+  apply1(?DEFAULT_MODE, ?DEFAULT_OUTPUT_FILE, {F, A}).
 
 apply(M, F, A) ->
-    apply1(?DEFAULT_MODE, ?DEFAULT_OUTPUT_FILE, {{M, F}, A}).
+  apply1(?DEFAULT_MODE, ?DEFAULT_OUTPUT_FILE, {{M, F}, A}).
 
 apply(Mode, OutputFile, Fun, Args) ->
-    apply1(Mode, OutputFile, {Fun, Args}).
+  apply1(Mode, OutputFile, {Fun, Args}).
 
 apply(Mode, OutputFile, M, F, A) ->
-    apply1(Mode, OutputFile, {{M, F}, A}).
+  apply1(Mode, OutputFile, {{M, F}, A}).
 
 apply1(Mode, OutputFile, {Fun, Args}) ->
-    Tracer = spawn_tracer(),
+  Tracer = spawn_tracer(),
 
-    start_trace(Tracer, self(), Mode),
+  start_trace(Tracer, self(), Mode),
+  Return = (catch apply_fun(Fun, Args)),
+  {ok, Bytes} = stop_trace(Tracer, self()),
 
-    spawn_link(fun() -> apply_fun(Fun, Args) end),
-
-    timer:sleep(10000),
-
-    {ok, Bytes} = stop_trace(Tracer, self()),
-
-    ok = file:write_file(OutputFile, Bytes).
+  ok = file:write_file(OutputFile, Bytes),
+  Return.
 
 apply_fun({M, F}, A) ->
-    erlang:apply(M, F, A);
+  erlang:apply(M, F, A);
 apply_fun(F, A) ->
-    erlang:apply(F, A).
+  erlang:apply(F, A).
 
 start_trace(Tracer, Target, Mode) ->
-    MatchSpec = [{'_', [], [{message, {{cp, {caller}}}}]}],
-    erlang:trace_pattern(on_load, MatchSpec, [local]),
-    erlang:trace_pattern({'_', '_', '_'}, MatchSpec, [local]),
-    erlang:trace(Target, true, [{tracer, Tracer} | trace_flags(Mode)]),
-    ok.
+  MatchSpec = [{'_', [], [{message, {{cp, {caller}}}}]}],
+  erlang:trace_pattern(on_load, MatchSpec, [local]),
+  erlang:trace_pattern({'_', '_', '_'}, MatchSpec, [local]),
+  erlang:trace(Target, true, [{tracer, Tracer} | trace_flags(Mode)]),
+  ok.
 
 stop_trace(Tracer, Target) ->
-    erlang:trace(Target, false, [all]),
-    Tracer ! {dump_bytes, self()},
+  erlang:trace(Target, false, [all]),
+  Tracer ! {dump_bytes, self()},
 
-    Ret = receive {bytes, B} -> {ok, B}
-    after 5000 -> {error, timeout}
-    end,
+  Ret = receive {bytes, B} -> {ok, B}
+        after 5000 -> {error, timeout}
+        end,
 
-    exit(Tracer, normal),
-    Ret.
+  exit(Tracer, normal),
+  Ret.
 
-spawn_tracer() -> spawn(fun() -> trace_listener(dict:new()) end).
+spawn_tracer() -> spawn(fun() -> trace_listener(#{}) end).
 
 trace_flags(normal) ->
-    [call, arity, return_to, timestamp, running];
+  [call, arity, return_to, timestamp, running];
 trace_flags(normal_with_children) ->
-    [call, arity, return_to, timestamp, running, set_on_spawn];
-trace_flags(like_fprof) -> % fprof does this as 'normal', will not work!
-    [call, return_to, running, procs, garbage_collection, arity, timestamp, set_on_spawn].
+  [call, arity, return_to, timestamp, running, set_on_spawn];
+trace_flags(like_fprof) ->
+  %% fprof does this as 'normal', will not work!
+  [ call, return_to, running
+  , procs, garbage_collection
+  , arity, timestamp, set_on_spawn
+  ].
 
-trace_listener(State) ->
-    receive
-        {dump, Pid} ->
-            Pid ! {stacks, dict:to_list(State)};
-        {dump_bytes, Pid} ->
-            Bytes = iolist_to_binary([dump_to_iolist(TPid, Dump) || {TPid, [Dump]} <- dict:to_list(State)]),
-            Pid ! {bytes, Bytes};
-        Term ->
-            trace_ts = element(1, Term),
-            PidS = element(2, Term),
+-spec trace_listener(map()) ->
+  {stacks, map()} | {bytes, binary()}.
+trace_listener(State0) ->
+  receive
+    {dump, Pid} ->
+      Pid ! {stacks, State0};
+    {dump_bytes, Pid} ->
+      IOList = [ dump_to_iolist(TPid, Dump)
+                 || {TPid, [Dump]} <- maps:to_list(State0)
+               ],
+      Bytes = iolist_to_binary(IOList),
+      Pid ! {bytes, Bytes};
+    Term ->
+      trace_ts  = element(1, Term),
+      Pid       = element(2, Term),
 
-            PidState = case dict:find(PidS, State) of
-                {ok, [Ps]} -> Ps;
-                error -> #dump{}
-            end,
+      PidState0 = maps:get(Pid, State0, #dump{}),
+      PidState1 = trace_proc_stream(Term, PidState0),
 
-            NewPidState = trace_proc_stream(Term, PidState),
-
-            D1 = dict:erase(PidS, State),
-            D2 = dict:append(PidS, NewPidState, D1),
-            trace_listener(D2)
-    end.
+      State1    = maps:put(Pid, State0, PidState1),
+      trace_listener(State1)
+  end.
 
 us({Mega, Secs, Micro}) ->
-    Mega*1000*1000*1000*1000 + Secs*1000*1000 + Micro.
+  Mega * 1000 * 1000 * 1000 * 1000 + Secs * 1000 * 1000 + Micro.
 
 new_state(#dump{us=Us, acc=Acc} = State, Stack, Ts) ->
-    %io:format("new state: ~p ~p ~p~n", [Us, length(Stack), Ts]),
-    UsTs = us(Ts),
-    case Us of
-        0 -> State#dump{us=UsTs, stack=Stack};
-        _ when Us > 0 ->
-            Diff = us(Ts) - Us,
-            NOverlaps = Diff div ?RESOLUTION,
-            Overlapped = NOverlaps * ?RESOLUTION,
-            %Rem = Diff - Overlapped,
-            case NOverlaps of
-                X when X >= 1 ->
-                    StackRev = lists:reverse(Stack),
-                    Stacks = [StackRev || _ <- lists:seq(1, NOverlaps)],
-                    State#dump{us=Us+Overlapped, acc=lists:append(Stacks, Acc), stack=Stack};
-                _ ->
-                    State#dump{stack=Stack}
-            end
-    end.
+  %% io:format("new state: ~p ~p ~p~n", [Us, length(Stack), Ts]),
+  UsTs = us(Ts),
+  case Us of
+    0 -> State#dump{us=UsTs, stack=Stack};
+    _ when Us > 0 ->
+      Diff = us(Ts) - Us,
+      NOverlaps = Diff div ?RESOLUTION,
+      Overlapped = NOverlaps * ?RESOLUTION,
+      %% Rem = Diff - Overlapped,
+      case NOverlaps of
+        X when X >= 1 ->
+          StackRev = lists:reverse(Stack),
+          Stacks = [StackRev || _ <- lists:seq(1, NOverlaps)],
+          State#dump{us=Us+Overlapped, acc=lists:append(Stacks, Acc), stack=Stack};
+        _ ->
+          State#dump{stack=Stack}
+      end
+  end.
 
-trace_proc_stream({trace_ts, _Ps, call, MFA, {cp, {_,_,_} = CallerMFA}, Ts}, #dump{stack=[]} = State) ->
-    new_state(State, [MFA, CallerMFA], Ts);
-
-trace_proc_stream({trace_ts, _Ps, call, MFA, {cp, undefined}, Ts}, #dump{stack=[]} = State) ->
-    new_state(State, [MFA], Ts);
-
-trace_proc_stream({trace_ts, _Ps, call, MFA, {cp, undefined}, Ts}, #dump{stack=[MFA|_] = Stack} = State) ->
-    new_state(State, Stack, Ts);
-
-trace_proc_stream({trace_ts, _Ps, call, MFA, {cp, undefined}, Ts}, #dump{stack=Stack} = State) ->
-    new_state(State, [MFA | Stack], Ts);
-
-trace_proc_stream({trace_ts, _Ps, call, MFA, {cp, MFA}, Ts}, #dump{stack=[MFA|Stack]} = State) ->
-    new_state(State, [MFA|Stack], Ts); % collapse tail recursion
-
-trace_proc_stream({trace_ts, _Ps, call, MFA, {cp, CpMFA}, Ts}, #dump{stack=[CpMFA|Stack]} = State) ->
-    new_state(State, [MFA, CpMFA|Stack], Ts);
-
-trace_proc_stream({trace_ts, _Ps, call, _MFA, {cp, _}, _Ts} = TraceTs, #dump{stack=[_|StackRest]} = State) ->
-    trace_proc_stream(TraceTs, State#dump{stack=StackRest});
-
-trace_proc_stream({trace_ts, _Ps, return_to, MFA, Ts}, #dump{stack=[_Current, MFA|Stack]} = State) ->
-    new_state(State, [MFA|Stack], Ts); % do not try to traverse stack down because we've already collapsed it
-
+trace_proc_stream( {trace_ts, _Ps, call, MFA, {cp, {_,_,_} = CallerMFA}, Ts}
+                 , #dump{stack=[]} = State
+                 ) ->
+  new_state(State, [MFA, CallerMFA], Ts);
+trace_proc_stream( {trace_ts, _Ps, call, MFA, {cp, undefined}, Ts}
+                 , #dump{stack=[]} = State
+                 ) ->
+  new_state(State, [MFA], Ts);
+trace_proc_stream( {trace_ts, _Ps, call, MFA, {cp, undefined}, Ts}
+                 , #dump{stack=[MFA|_] = Stack} = State
+                 ) ->
+  new_state(State, Stack, Ts);
+trace_proc_stream( {trace_ts, _Ps, call, MFA, {cp, undefined}, Ts}
+                 , #dump{stack=Stack} = State
+                 ) ->
+  new_state(State, [MFA | Stack], Ts);
+trace_proc_stream( {trace_ts, _Ps, call, MFA, {cp, MFA}, Ts}
+                 , #dump{stack=[MFA|Stack]} = State
+                 ) ->
+  new_state(State, [MFA|Stack], Ts); % collapse tail recursion
+trace_proc_stream( {trace_ts, _Ps, call, MFA, {cp, CpMFA}, Ts}
+                 , #dump{stack=[CpMFA|Stack]} = State
+                 ) ->
+  new_state(State, [MFA, CpMFA|Stack], Ts);
+trace_proc_stream( {trace_ts, _Ps, call, _MFA, {cp, _}, _Ts} = TraceTs
+                 , #dump{stack=[_|StackRest]} = State
+                 ) ->
+  trace_proc_stream(TraceTs, State#dump{stack=StackRest});
+trace_proc_stream( {trace_ts, _Ps, return_to, MFA, Ts}
+                 , #dump{stack=[_Current, MFA|Stack]} = State
+                 ) ->
+  %% do not try to traverse stack down because we've already collapsed it
+  new_state(State, [MFA|Stack], Ts);
 trace_proc_stream({trace_ts, _Ps, return_to, undefined, _Ts}, State) ->
-    State;
-
+  State;
 trace_proc_stream({trace_ts, _Ps, return_to, _, _Ts}, State) ->
-    State;
-
-trace_proc_stream({trace_ts, _Ps, in, _MFA, Ts}, #dump{stack=[sleep|Stack]} = State) ->
-    new_state(new_state(State, [sleep|Stack], Ts), Stack, Ts);
-
-trace_proc_stream({trace_ts, _Ps, in, _MFA, Ts}, #dump{stack=Stack} = State) ->
-    new_state(State, Stack, Ts);
-
-trace_proc_stream({trace_ts, _Ps, out, _MFA, Ts}, #dump{stack=Stack} = State) ->
-    new_state(State, [sleep|Stack], Ts);
-
+  State;
+trace_proc_stream( {trace_ts, _Ps, in, _MFA, Ts}
+                 , #dump{stack=[sleep|Stack]} = State
+                 ) ->
+  new_state(new_state(State, [sleep|Stack], Ts), Stack, Ts);
+trace_proc_stream( {trace_ts, _Ps, in, _MFA, Ts}
+                 , #dump{stack=Stack} = State
+                 ) ->
+  new_state(State, Stack, Ts);
+trace_proc_stream( {trace_ts, _Ps, out, _MFA, Ts}
+                 , #dump{stack=Stack} = State
+                 ) ->
+  new_state(State, [sleep|Stack], Ts);
 trace_proc_stream(TraceTs, State) ->
-    io:format("trace_proc_stream: unknown trace: ~p~n", [TraceTs]),
-    State.
-
+  io:format("trace_proc_stream: unknown trace: ~p~n", [TraceTs]),
+  State.
 stack_collapse(Stack) ->
-    intercalate(";", [entry_to_iolist(S) || S <- Stack]).
+  intercalate(";", [entry_to_iolist(S) || S <- Stack]).
 
 entry_to_iolist({M, F, A}) ->
-    [atom_to_binary(M, utf8), <<":">>, atom_to_binary(F, utf8), <<"/">>, integer_to_list(A)];
+  [ atom_to_binary(M, utf8), <<":">>
+  , atom_to_binary(F, utf8), <<"/">>
+  , integer_to_list(A)
+  ];
 entry_to_iolist(A) when is_atom(A) ->
-    [atom_to_binary(A, utf8)].
+  [atom_to_binary(A, utf8)].
 
 dump_to_iolist(Pid, #dump{acc=Acc}) ->
-    [[pid_to_list(Pid), <<";">>, stack_collapse(S), <<"\n">>] || S <- lists:reverse(Acc)].
+  [ [ pid_to_list(Pid), <<";">>
+    , stack_collapse(S), <<"\n">>
+    ]
+    || S <- lists:reverse(Acc)
+  ].
 
 intercalate(Sep, Xs) -> lists:concat(intersperse(Sep, Xs)).
 

--- a/src/eflame.erl
+++ b/src/eflame.erl
@@ -11,6 +11,9 @@
 -define(DEFAULT_MODE, normal_with_children).
 -define(DEFAULT_OUTPUT_FILE, "stacks.out").
 
+-define(LOG(Msg, Args), io:format(Msg, Args)).
+-define(LOG(Msg), ?LOG(Msg, [])).
+
 apply(F, A) ->
   apply1(?DEFAULT_MODE, ?DEFAULT_OUTPUT_FILE, {F, A}).
 
@@ -76,12 +79,14 @@ trace_listener(State0) ->
     {dump, Pid} ->
       Pid ! {stacks, State0};
     {dump_bytes, Pid} ->
+      ?LOG("Dumping bytes..."),
       IOList = [ dump_to_iolist(TPid, Dump)
                  || {TPid, [Dump]} <- maps:to_list(State0)
                ],
       Bytes = iolist_to_binary(IOList),
       Pid ! {bytes, Bytes};
     Term ->
+      ?LOG("Term: ~p", [Term]),
       trace_ts  = element(1, Term),
       Pid       = element(2, Term),
 

--- a/stack_to_flame.sh
+++ b/stack_to_flame.sh
@@ -2,4 +2,4 @@
 
 me="$(dirname $0)"
 
-uniq -c | awk '{print $2, " ", $1}' | $me/flamegraph.pl
+$me/flamegraph.pl $1


### PR DESCRIPTION
- Uses maps instead of `dict:dict()`.
- Avoid doing list processing when handling trace messages.
- Remove unnecessary list processing when building the `iolist()`.
- Consolidate multiplications of `1000`s into constants.
- Run the tracing for a maximum of `DEFAULT_TIMEOUT` to avoid getting a huge state in the tracer process (this can be modified so it can be provided as an option).
- Avoid having to generate multiple entries in the output by producing the format `flamegraph.pl` expects.

The result from this improvements is that `eflame` is now able to return a result for simple benchmarks and it doesn't timeout when it's waiting for the response of `dump_bytes`.