### PR TITLE
fix invalid SVG due to nested double-quote

### DIFF
--- a/flamegraph.pl
+++ b/flamegraph.pl
@@ -797,6 +797,7 @@ while (my ($id, $node) = each %Node) {
 		$escaped_func =~ s/&/&amp;/g;
 		$escaped_func =~ s/</&lt;/g;
 		$escaped_func =~ s/>/&gt;/g;
+		$escaped_func =~ s/"//g;
 		unless (defined $delta) {
 			$info = "$escaped_func ($samples_txt $countname, $pct%)";
 		} else {


### PR DESCRIPTION
### Issue
It is possible to generate output with function names that contain double quotes. Because the function name is already inside a double-quoted attribute, this causes the SVG to be invalid.

### Fix
Remove double quotes from function names

### Example

Before:
```
<g onmouseover="s('function_name"-something" (17,157 samples, 100%)')">
```

After:
```
<g onmouseover="s('function_name-something (17,157 samples, 100%)')">
```