### PR TITLE
Add configurable timeout for `stop_trace` (cont.)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ ebin/*
 *.svg
 *.out
 erl_crash.dump
+.rebar

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ Make sure to check out his talk, [Actively Measuring And Profiling Erlang Code](
 Usage example: https://github.com/proger/active/commit/81e7e40c9dc5a4666742636ea4c5dfafc41508a5
 
 ```erlang
-> eflame:apply(normal_with_children, "stacks.out", my_module, awesome_calculation, []).
+> eflame:apply(my_module, awesome_calculation, [], #{mode => normal_with_children, output_file => "stacks.out"}).
 > eflame:apply(my_module, awesome_calculation, []). % same as above
 > eflame:apply(fun my_module:awesome_calculation/0, []). % same as above
 > eflame:apply(fun awesome_calculation/0, []). % same as above, when called in my_module.erl
-> eflame:apply(normal, "stacks.out", my_module, awesome_calculation, []). % won't trace children
+> eflame:apply(my_module, awesome_calculation, [], #{mode => normal, output_file => "stacks.out"}). % won't trace children
 ```
 
 ```sh

--- a/src/eflame.erl
+++ b/src/eflame.erl
@@ -1,41 +1,30 @@
 -module(eflame).
 -export([apply/2,
          apply/3,
-         apply/4,
-         apply/5,
-         apply/6]).
+         apply/4]).
 
 -define(RESOLUTION, 1000). %% us
 -record(dump, {stack=[], us=0, acc=[]}). % per-process state
 
 -define(DEFAULT_MODE, normal_with_children).
 -define(DEFAULT_OUTPUT_FILE, "stacks.out").
--define(DEFAULT_OPTIONS, #{timeout => 5000}).
+-define(DEFAULT_OPTIONS, #{timeout => 5000, mode => ?DEFAULT_MODE, output_file => ?DEFAULT_OUTPUT_FILE}).
 
 apply(F, A) ->
-    apply1(?DEFAULT_MODE, ?DEFAULT_OUTPUT_FILE, {F, A}, ?DEFAULT_OPTIONS).
+    apply1({F, A}, ?DEFAULT_OPTIONS).
 
 apply(F, A, O) when is_map(O) ->
-    apply1(?DEFAULT_MODE, ?DEFAULT_OUTPUT_FILE, {F, A}, O);
+    apply1({F, A}, O);
+
 apply(M, F, A) ->
-    apply1(?DEFAULT_MODE, ?DEFAULT_OUTPUT_FILE, {{M, F}, A}, ?DEFAULT_OPTIONS).
+    apply1({{M, F}, A}, ?DEFAULT_OPTIONS).
 
 apply(M, F, A, O) when is_map(O) ->
-    apply1(?DEFAULT_MODE, ?DEFAULT_OUTPUT_FILE, {{M, F}, A}, O);
-apply(Mode, OutputFile, Fun, Args) ->
-    apply1(Mode, OutputFile, {Fun, Args}, ?DEFAULT_OPTIONS).
+    apply1({{M, F}, A}, O).
 
-apply(Mode, OutputFile, Fun, Args, O) when is_map(O) ->
-    apply1(Mode, OutputFile, {Fun, Args}, O);
-apply(Mode, OutputFile, M, F, A) ->
-    apply1(Mode, OutputFile, {{M, F}, A}, ?DEFAULT_OPTIONS).
-
-apply(Mode, OutputFile, M, F, A, O) when is_map(O) ->
-    apply1(Mode, OutputFile, {{M, F}, A}, O).
-
-apply1(Mode, OutputFile, {Fun, Args}, Options) ->
+apply1({Fun, Args}, Options) ->
     Tracer = spawn_tracer(),
-    #{timeout := Timeout} = Options,
+    #{timeout := Timeout, mode := Mode, output_file := OutputFile} = maps:merge(?DEFAULT_OPTIONS, Options),
 
     start_trace(Tracer, self(), Mode),
     Return = (catch apply_fun(Fun, Args)),


### PR DESCRIPTION
This is a continuation of PR https://github.com/proger/eflame/pull/15, that was 
Fixes https://github.com/proger/eflame/issues/13

The change added is moving the `Mode` and `OutputFile` parameters to `Options`. Note this is a **breaking change**.